### PR TITLE
Revert "add #respond_to? support to the delegator"

### DIFF
--- a/lib/delegate_missing_to.rb
+++ b/lib/delegate_missing_to.rb
@@ -40,13 +40,6 @@ module DelegateMissingTo
         end
 
         alias_method_chain :method_missing, "delegation_to_#{object_name}"
-
-        define_method "respond_to_with_delegation_to_#{object_name}?" do |symbol, include_all = false|
-          send("respond_to_without_delegation_to_#{object_name}?", symbol, include_all) ||
-            send(object_name).respond_to?(symbol)
-        end
-
-        alias_method_chain :respond_to?, "delegation_to_#{object_name}"
       end
     end
   end


### PR DESCRIPTION
This realisation causes a deadlock when Rails try to run finder callbacks.
Also there's no need to redefine `#respond_to?` method at all. We should use explicit delegation with standard `.delegate` method if we need an object both to delegate & respond to the call.
So, it was a mistake to redefine `#respond_to?` and the fix is just this revert.
